### PR TITLE
Pass request context though downstream tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A `task` is an [interface](https://go.dev/tour/methods/9) with `run` and `name` 
 type task interface {
 	// Run takes a signup form struct and executes some action.
 	// Ex.: Send an email, post a Slack message.
-	run(signup Signup) error
+	run(context.Context, Signup) error
 	// Name Returns the name of the task.
 	name() string
 }

--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ server := newSignupServer(registrationService)
 ```go
 // Register executes a series of tasks in order. If one fails, the remaining tasks are cancelled.
 func (sc *SignupService) register(su Signup) error {
-	// TODO: Create specific errors for each handler
-	// TODO: Use context.Context to cancel subsequent requests on any failures
 	for _, task := range sc.tasks {
 		err := task.run(su)
 		if err != nil {

--- a/greenlight.go
+++ b/greenlight.go
@@ -20,8 +20,8 @@ func NewGreenlightService(url, apiKey string) *greenlightService {
 	}
 }
 
-func (g greenlightService) run(su Signup) error {
-	return g.postWebhook(su)
+func (g greenlightService) run(ctx context.Context, su Signup) error {
+	return g.postWebhook(ctx, su)
 }
 
 func (g greenlightService) name() string {
@@ -30,14 +30,14 @@ func (g greenlightService) name() string {
 
 // PostWebhook sends a webhook to Greenlight (POST /signup).
 // The webhook creates a Info Session Signup record in the Greenlight database.
-func (g greenlightService) postWebhook(su Signup) error {
+func (g greenlightService) postWebhook(ctx context.Context, su Signup) error {
 	reqBody, err := json.Marshal(su)
 	if err != nil {
 		return fmt.Errorf("marshal: %v", err)
 	}
 
 	req, err := http.NewRequestWithContext(
-		context.TODO(),
+		ctx,
 		http.MethodPost,
 		g.url,
 		bytes.NewBuffer(reqBody),

--- a/greenlight_test.go
+++ b/greenlight_test.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -39,6 +40,6 @@ func TestPostWebhook(t *testing.T) {
 
 		glSvc := NewGreenlightService(mockGreenlightSvr.URL, apiKey)
 
-		glSvc.postWebhook(su)
+		glSvc.postWebhook(context.Background(), su)
 	})
 }

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -68,7 +69,7 @@ func TestSendWelcome(t *testing.T) {
 
 		mgSvc := NewMailgunService(domain, apiKey, mockMailgunAPI.URL+"/v4")
 
-		err := mgSvc.sendWelcome(form)
+		err := mgSvc.sendWelcome(context.Background(), form)
 
 		if err != nil {
 			t.Fatalf("send welcome: %v", err)
@@ -92,7 +93,7 @@ func TestSendWelcome(t *testing.T) {
 			mockMailgunAPI.URL+"/v4",
 		)
 
-		err := mgSvc.sendWelcome(Signup{})
+		err := mgSvc.sendWelcome(context.Background(), Signup{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,7 @@ import (
 )
 
 type registerer interface {
-	register(signup Signup) error
+	register(ctx context.Context, signup Signup) error
 }
 
 type signupServer struct {
@@ -49,7 +50,7 @@ func (ss *signupServer) HandleSignUp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := ss.service.register(su)
+	err := ss.service.register(r.Context(), su)
 	// depending on what we get back, respond accordingly
 	if err != nil {
 		// TODO: handle different kinds of errors differently

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package signup
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,11 +11,11 @@ import (
 )
 
 type MockSignupService struct {
-	RegisterFunc func(signup Signup) error
+	RegisterFunc func(context.Context, Signup) error
 }
 
-func (m *MockSignupService) register(signup Signup) error {
-	return m.RegisterFunc(signup)
+func (m *MockSignupService) register(ctx context.Context, signup Signup) error {
+	return m.RegisterFunc(ctx, signup)
 }
 
 func TestHandleSignup(t *testing.T) {
@@ -29,7 +30,7 @@ func TestHandleSignup(t *testing.T) {
 		}
 
 		service := &MockSignupService{
-			RegisterFunc: func(signup Signup) error {
+			RegisterFunc: func(context.Context, Signup) error {
 				return nil
 			},
 		}

--- a/signup.go
+++ b/signup.go
@@ -113,7 +113,6 @@ func newSignupService(o signupServiceOptions) *SignupService {
 // Register executes a series of tasks in order. If one fails, the remaining tasks are cancelled.
 func (sc *SignupService) register(ctx context.Context, su Signup) error {
 	// TODO: Create specific errors for each handler
-	// TODO: Use context.Context to cancel subsequent requests on any failures
 	sc.attachZoomMeetingID(&su)
 	for _, task := range sc.tasks {
 		err := task.run(ctx, su)

--- a/signup.go
+++ b/signup.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -41,7 +42,7 @@ type (
 	task interface {
 		// Run takes a signup form struct and executes some action.
 		// Ex.: Send an email, post a Slack message.
-		run(signup Signup) error
+		run(ctx context.Context, signup Signup) error
 		// Name Returns the name of the task.
 		name() string
 	}
@@ -110,12 +111,12 @@ func newSignupService(o signupServiceOptions) *SignupService {
 }
 
 // Register executes a series of tasks in order. If one fails, the remaining tasks are cancelled.
-func (sc *SignupService) register(su Signup) error {
+func (sc *SignupService) register(ctx context.Context, su Signup) error {
 	// TODO: Create specific errors for each handler
 	// TODO: Use context.Context to cancel subsequent requests on any failures
 	sc.attachZoomMeetingID(&su)
 	for _, task := range sc.tasks {
-		err := task.run(su)
+		err := task.run(ctx, su)
 		if err != nil {
 			return fmt.Errorf("task failed: %q: %v", task.name(), err)
 		}

--- a/signup_test.go
+++ b/signup_test.go
@@ -2,6 +2,7 @@ package signup
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -11,13 +12,13 @@ import (
 )
 
 type MockMailgunService struct {
-	WelcomeFunc func(Signup) error
+	WelcomeFunc func(context.Context, Signup) error
 	called      bool
 }
 
-func (ms *MockMailgunService) run(su Signup) error {
+func (ms *MockMailgunService) run(ctx context.Context, su Signup) error {
 	ms.called = true
-	return ms.WelcomeFunc(su)
+	return ms.WelcomeFunc(ctx, su)
 }
 
 func (ms *MockMailgunService) name() string {
@@ -36,7 +37,7 @@ func TestRegisterUser(t *testing.T) {
 		}
 
 		mailService := &MockMailgunService{
-			WelcomeFunc: func(s Signup) error {
+			WelcomeFunc: func(ctx context.Context, s Signup) error {
 				return nil
 			},
 		}
@@ -45,7 +46,7 @@ func TestRegisterUser(t *testing.T) {
 			tasks: []task{mailService},
 		})
 
-		err := signupService.register(signup)
+		err := signupService.register(context.Background(), signup)
 		if err != nil {
 			t.Fatalf("register: %v", err)
 		}

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,7 @@ func TestSendWebhook(t *testing.T) {
 			assertEqual(t, payload["text"], msg.Text)
 		}))
 
-		err := sendWebhook(slackAPI.URL, msg)
+		err := sendWebhook(context.Background(), slackAPI.URL, msg)
 		if err != nil {
 			t.Fatalf("sendWebhook: %v", err)
 		}

--- a/zoom.go
+++ b/zoom.go
@@ -68,12 +68,12 @@ func NewZoomService(o ZoomOptions) *zoomService {
 	}
 }
 
-func (z *zoomService) run(su Signup) error {
+func (z *zoomService) run(ctx context.Context, su Signup) error {
 	// Do nothing if the user has not signed up for a specific session
 	if su.StartDateTime.IsZero() {
 		return nil
 	}
-	return z.registerUser(su)
+	return z.registerUser(ctx, su)
 }
 
 func (z *zoomService) name() string {
@@ -81,10 +81,10 @@ func (z *zoomService) name() string {
 }
 
 // RegisterUser creates and submits a user's registration to a meeting. The specific meeting is decided from the Signup's startDateTime.
-func (z *zoomService) registerUser(su Signup) error {
+func (z *zoomService) registerUser(ctx context.Context, su Signup) error {
 	// Authenticate client
 	if !z.isAuthenticated() {
-		if err := z.authenticate(); err != nil {
+		if err := z.authenticate(ctx); err != nil {
 			return fmt.Errorf("authenticate: %v", err)
 		}
 	}
@@ -109,7 +109,7 @@ func (z *zoomService) registerUser(su Signup) error {
 	)
 
 	req, err := http.NewRequestWithContext(
-		context.TODO(),
+		ctx,
 		http.MethodPost,
 		url,
 		bytes.NewBuffer(jsonBody),
@@ -138,11 +138,11 @@ func (z *zoomService) registerUser(su Signup) error {
 }
 
 // Authenticate requests an access token and sets it along with the expiration date on the service.
-func (z *zoomService) authenticate() error {
+func (z *zoomService) authenticate(ctx context.Context) error {
 	url := fmt.Sprintf("%s/token?grant_type=account_credentials&account_id=%s", z.oauthURL, z.accountID)
 	// Make a HTTP req to authenticate the client
 	req, err := http.NewRequestWithContext(
-		context.TODO(),
+		ctx,
 		http.MethodPost,
 		url,
 		nil,

--- a/zoom_test.go
+++ b/zoom_test.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -21,7 +22,7 @@ func TestRun(t *testing.T) {
 			baseAPIOverride: mockAPIServer.URL,
 		})
 
-		err := zsvc.run(su)
+		err := zsvc.run(context.Background(), su)
 		if err != nil {
 			t.Fatalf("run: %v", err)
 		}
@@ -88,7 +89,7 @@ func TestAuthenticate(t *testing.T) {
 			clientSecret:      fakeClientSecret,
 			accountID:         fakeAccountID,
 		})
-		err := zsvc.authenticate()
+		err := zsvc.authenticate(context.Background())
 		if err != nil {
 			t.Fatalf("authenticate: %v", err)
 		}
@@ -174,7 +175,7 @@ func TestRegisterForMeeting(t *testing.T) {
 	zsvc.tokenExpiresAt = time.Now().Add(time.Minute * 10)
 
 	// Method under test
-	err := zsvc.registerUser(su)
+	err := zsvc.registerUser(context.Background(), su)
 	if err != nil {
 		t.Fatalf("register for meeting: %v", err)
 	}


### PR DESCRIPTION
Pass request context to downstream tasks so they're canceled if client cancels the initial request.

https://cloud.google.com/functions/docs/concepts/go-runtime#contextcontext
https://go.dev/blog/context