### PR TITLE
Fallback to original URL if shortener fails

### DIFF
--- a/shorty_test.go
+++ b/shorty_test.go
@@ -48,4 +48,21 @@ func TestShortenURL(t *testing.T) {
 			t.Fatalf("want %q, but got %q", wantURL, got)
 		}
 	})
+
+	t.Run("returns the original URL if an error occurs", func(t *testing.T) {
+		originalURL := "http://thisisalongurl.gov/q?x=1&morestuff=everything"
+		wantURL := originalURL
+
+		shorty := NewURLShortener(ShortenerOpts{})
+		got, err := shorty.ShortenURL(context.Background(), originalURL)
+		if err == nil {
+			// Error should be EOF since there is no server to communicate with.
+			// The error type is irrelevant though.
+			t.Fatal("Error should not be nil")
+		}
+
+		if got != wantURL {
+			t.Fatalf("want original URL on errors:\n%q, but got:\n%q", wantURL, got)
+		}
+	})
 }

--- a/twilio.go
+++ b/twilio.go
@@ -104,7 +104,9 @@ func (t *smsService) run(ctx context.Context, su Signup) error {
 
 	shortLink, err := shorty.ShortenURL(ctx, mgsngURL)
 	if err != nil {
-		return fmt.Errorf("shortenURL: %v", err)
+		fmt.Fprintf(os.Stderr, "shortenURL ERROR: %v", err)
+		// Don't early return. ShortenURL returns the original URL if there is a failure
+		// Fallback to long URL if shortener fails
 	}
 
 	// Create the SMS message body


### PR DESCRIPTION
In the case of an error with the URL shortener service, use the original "long' URL for messaging.