### PR TITLE
Chore: Better Error Messaging, testing env CD workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Ru Test
+      - name: Run Tests
         run: |
           go test -v ./... -covermode=count -coverprofile=coverage.out
           go tool cover -func=coverage.out -o=coverage.out

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -1,0 +1,48 @@
+name: GCP Cloud Functions Deploy (Testing)
+on:
+  push:
+    branches:
+      - "testing"
+jobs:
+  build-deploy-cloud-function:
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    environment: testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.GCP_SA_CREDS_JSON }}"
+
+      - id: "deploy"
+        uses: "google-github-actions/deploy-cloud-functions@v0"
+        with:
+          name: "session-signups-testing"
+          entry_point: "HandleSignUp"
+          https_trigger_security_level: "secure-always"
+          project_id: "operationspark-org"
+          region: "us-central1"
+          runtime: "go116"
+          env_vars: >-
+            SLACK_WEBHOOK_URL=${{secrets.SLACK_WEBHOOK_URL}},
+            MAIL_DOMAIN=${{secrets.MAIL_DOMAIN}},
+            MAILGUN_API_KEY=${{secrets.MAILGUN_API_KEY}},
+            GREENLIGHT_WEBHOOK_URL=${{secrets.GREENLIGHT_WEBHOOK_URL}},
+            ZOOM_ACCOUNT_ID=${{secrets.ZOOM_ACCOUNT_ID}},
+            ZOOM_CLIENT_ID=${{secrets.ZOOM_CLIENT_ID}},
+            ZOOM_CLIENT_SECRET=${{secrets.ZOOM_CLIENT_SECRET}},
+            ZOOM_MEETING_12=${{secrets.ZOOM_MEETING_12}},
+            ZOOM_MEETING_17=${{secrets.ZOOM_MEETING_17}},
+            TWILIO_ACCOUNT_SID=${{secrets.TWILIO_ACCOUNT_SID}},
+            TWILIO_AUTH_TOKEN=${{secrets.TWILIO_AUTH_TOKEN}},
+            TWILIO_PHONE_NUMBER=${{secrets.TWILIO_PHONE_NUMBER}},
+            TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
+            URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
+            APP_ENV=testing
+      - id: "trigger-url"
+        run: 'echo "${{ steps.deploy.outputs.url }}"'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Session Sign Up Service
-![Coverage](https://img.shields.io/badge/Coverage-59.6%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-59.7%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/errors.go
+++ b/errors.go
@@ -20,5 +20,13 @@ func handleHTTPError(resp *http.Response) error {
 	if err != nil {
 		return fmt.Errorf("response Body: %s", resp.Status)
 	}
-	return fmt.Errorf("HTTP: %s\nresponse body: %s", resp.Status, string(body))
+
+	reqLabel := fmt.Sprintf(
+		"%s: %s://%s\n%s\n",
+		resp.Request.Method,
+		resp.Request.URL.Scheme,
+		resp.Request.URL.Host,
+		resp.Request.URL.RequestURI(),
+	)
+	return fmt.Errorf("HTTP Error:\n%s\nResponse:\n%s\n%s", reqLabel, resp.Status, string(body))
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,54 @@
+package signup
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type JSONErr struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func TestHandleHTTPError(t *testing.T) {
+	t.Run("prints the request context and HTTP Error response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tooManyErr := JSONErr{
+				Code:    http.StatusTooManyRequests,
+				Message: "You have exceeded the daily rate limit of (3) for Add meeting registrant API requests for the registrant (ahlerjia+test@example.com). You can resume these API requests at GMT 00:00:00.",
+			}
+			JSONError(w, tooManyErr, http.StatusTooManyRequests)
+		}))
+
+		resp, err := http.DefaultClient.Get(srv.URL + "/v2/meetings/89012345678/registrants?occurrence_id=1665594000000")
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotErr := handleHTTPError(resp)
+		if gotErr == nil {
+			t.Fatal("unexpected nil err")
+		}
+
+		want := fmt.Sprintf(`HTTP Error:
+GET: %s
+/v2/meetings/89012345678/registrants?occurrence_id=1665594000000
+
+Response:
+429 Too Many Requests
+{"code":429,"message":"You have exceeded the daily rate limit of (3) for Add meeting registrant API requests for the registrant (ahlerjia+test@example.com). You can resume these API requests at GMT 00:00:00."}
+`, srv.URL)
+
+		assertEqual(t, gotErr.Error(), want)
+
+	})
+}
+
+// JSONError writes an HTTP error code and a JSON structured error body to an HTTP response.
+func JSONError(w http.ResponseWriter, err interface{}, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(err)
+}

--- a/greenlight.go
+++ b/greenlight.go
@@ -33,7 +33,7 @@ func (g greenlightService) name() string {
 func (g greenlightService) postWebhook(ctx context.Context, su Signup) error {
 	reqBody, err := json.Marshal(su)
 	if err != nil {
-		return fmt.Errorf("marshal: %v", err)
+		return fmt.Errorf("marshal: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(
@@ -43,14 +43,14 @@ func (g greenlightService) postWebhook(ctx context.Context, su Signup) error {
 		bytes.NewBuffer(reqBody),
 	)
 	if err != nil {
-		return fmt.Errorf("newRequest: %v", err)
+		return fmt.Errorf("newRequest: %w", err)
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Greenlight-Signup-Api-Key", g.apiKey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("POST request: %v", err)
+		return fmt.Errorf("POST request: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/mailgun.go
+++ b/mailgun.go
@@ -42,7 +42,7 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 
 	vars, err := su.welcomeData()
 	if err != nil {
-		return fmt.Errorf("welcomeData: %v", err)
+		return fmt.Errorf("welcomeData: %w", err)
 	}
 
 	t := mgTemplate{
@@ -83,7 +83,7 @@ func (m MailgunService) sendWithTemplate(ctx context.Context, t mgTemplate, reci
 	for k, v := range t.variables {
 		err := message.AddTemplateVariable(k, v)
 		if err != nil {
-			return fmt.Errorf("add template variable: %v ", err)
+			return fmt.Errorf("add template variable: %w ", err)
 		}
 	}
 
@@ -93,7 +93,7 @@ func (m MailgunService) sendWithTemplate(ctx context.Context, t mgTemplate, reci
 	// Send the message with a 10 second timeout
 	_, _, err := m.mgClient.Send(ctxWithTimeout, message)
 	if err != nil {
-		return fmt.Errorf("send: %v", err)
+		return fmt.Errorf("send: %w", err)
 	}
 
 	return nil

--- a/shorty.go
+++ b/shorty.go
@@ -62,31 +62,31 @@ func NewURLShortener(o ShortenerOpts) *Shortener {
 func (s Shortener) ShortenURL(ctx context.Context, url string) (string, error) {
 	body, err := json.Marshal(ShortLink{OriginalUrl: url})
 	if err != nil {
-		return url, fmt.Errorf("marshall: %v", err)
+		return url, fmt.Errorf("marshall: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseApiEndpoint, bytes.NewReader(body))
 	if err != nil {
-		return url, fmt.Errorf("newRequestWithContext: %v", err)
+		return url, fmt.Errorf("newRequestWithContext: %w", err)
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("key", s.apiKey)
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return url, fmt.Errorf("post: %v", err)
+		return url, fmt.Errorf("post: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		return url, fmt.Errorf("post: %v", handleHTTPError(resp))
+		return url, fmt.Errorf("post: %w", handleHTTPError(resp))
 	}
 
 	d := json.NewDecoder(resp.Body)
 	var link ShortLink
 	err = d.Decode(&link)
 	if err != nil {
-		return url, fmt.Errorf("decode: %v", err)
+		return url, fmt.Errorf("decode: %w", err)
 	}
 
 	return link.ShortURL, nil

--- a/signup.go
+++ b/signup.go
@@ -150,7 +150,7 @@ func (su Signup) shortMessage(infoURL string) (string, error) {
 	// Set times to Central time
 	ctz, err := time.LoadLocation("America/Chicago")
 	if err != nil {
-		return "", fmt.Errorf("loadLocation: %v", err)
+		return "", fmt.Errorf("loadLocation: %w", err)
 	}
 	infoTime := su.StartDateTime.In(ctz).Format("3:04p MST")
 	infoDate := su.StartDateTime.In(ctz).Format("Mon Jan 02")
@@ -181,7 +181,7 @@ func (su Signup) shortMessagingURL(baseURL string) (string, error) {
 	}
 	encoded, err := structToBase64(p)
 	if err != nil {
-		return "", fmt.Errorf("structToBase64: %v", err)
+		return "", fmt.Errorf("structToBase64: %w", err)
 	}
 	return fmt.Sprintf("%s/m/%s", baseURL, encoded), nil
 
@@ -204,7 +204,7 @@ func (su Signup) String() string {
 func structToBase64(v interface{}) (string, error) {
 	j, err := json.Marshal(v)
 	if err != nil {
-		return "", fmt.Errorf("marshall: %v", err)
+		return "", fmt.Errorf("marshall: %w", err)
 	}
 
 	return base64.URLEncoding.EncodeToString(j), nil
@@ -224,12 +224,12 @@ func (sc *SignupService) register(ctx context.Context, su Signup) error {
 	sc.attachZoomMeetingID(&su)
 	err := sc.zoomService.run(ctx, &su)
 	if err != nil {
-		return fmt.Errorf("zoomService.run: %v", err)
+		return fmt.Errorf("zoomService.run: %w", err)
 	}
 	for _, task := range sc.tasks {
 		err := task.run(ctx, su)
 		if err != nil {
-			return fmt.Errorf("task failed: %q: %v", task.name(), err)
+			return fmt.Errorf("task failed: %q: %w", task.name(), err)
 		}
 	}
 	return nil
@@ -239,7 +239,7 @@ func (sc *SignupService) register(ctx context.Context, su Signup) error {
 func (sc *SignupService) attachZoomMeetingID(su *Signup) error {
 	loc, err := time.LoadLocation("America/Chicago")
 	if err != nil {
-		return fmt.Errorf("loadLocation: %v", err)
+		return fmt.Errorf("loadLocation: %w", err)
 	}
 	sessionStart := su.StartDateTime
 	centralStart := sessionStart.In(loc)
@@ -249,7 +249,7 @@ func (sc *SignupService) attachZoomMeetingID(su *Signup) error {
 	}
 	id, err := strconv.Atoi(sc.meetings[centralStart.Hour()])
 	if err != nil {
-		return fmt.Errorf("convert string to int: %v", err)
+		return fmt.Errorf("convert string to int: %w", err)
 	}
 	su.SetZoomMeetingID(int64(id))
 	return nil

--- a/slack.go
+++ b/slack.go
@@ -38,18 +38,18 @@ type message struct {
 func sendWebhook(ctx context.Context, url string, msg message) error {
 	body, err := json.Marshal(msg)
 	if err != nil {
-		return fmt.Errorf("marshall: %v", err)
+		return fmt.Errorf("marshall: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
-		return fmt.Errorf("new request: %v", err)
+		return fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("post request: %v", err)
+		return fmt.Errorf("post request: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/zoom.go
+++ b/zoom.go
@@ -85,7 +85,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 	// Authenticate client
 	if !z.isAuthenticated() {
 		if err := z.authenticate(ctx); err != nil {
-			return fmt.Errorf("authenticate: %v", err)
+			return fmt.Errorf("authenticate: %w", err)
 		}
 	}
 
@@ -97,7 +97,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 	}
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
-		return fmt.Errorf("marshall: %v", err)
+		return fmt.Errorf("marshall: %w", err)
 	}
 
 	// Register for a specific occurrence for the recurring meeting
@@ -115,7 +115,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 		bytes.NewBuffer(jsonBody),
 	)
 	if err != nil {
-		return fmt.Errorf("newRequestWithContext: %v", err)
+		return fmt.Errorf("newRequestWithContext: %w", err)
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", z.accessToken))
@@ -123,7 +123,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 
 	resp, err := z.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client.Do: %v", err)
+		return fmt.Errorf("client.Do: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -149,14 +149,14 @@ func (z *zoomService) authenticate(ctx context.Context) error {
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("NewRequestWithContext: %v", err)
+		return fmt.Errorf("NewRequestWithContext: %w", err)
 	}
 
 	req.Header.Add("Authorization", "Basic "+z.encodeCredentials())
 
 	resp, err := z.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client.do: %v", err)
+		return fmt.Errorf("client.do: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {


### PR DESCRIPTION
Resolves #30 
Resolves #27

#### Example Error Message:
```
HTTP Error:
POST: https://api.zoom.us
/v2/meetings/8912345678/registrants?occurrence_id=1665594000000

Response:
429 Too Many Requests
{"code":429,"message":"You have exceeded the daily rate limit of (3) for Add meeting registrant API requests for the registrant (someone@domain.org). You can resume these API requests at GMT 00:00:00."}
```