### PR TITLE
Check attachZoomMeetingID error

### DIFF
--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "testing"
-      - "feat/concurrent-reqs"
+      - "fix/zoom-meeting-error"
 
 jobs:
   build-deploy-cloud-function:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-63.3%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-63.2%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/signup.go
+++ b/signup.go
@@ -304,8 +304,11 @@ func newSignupService(o signupServiceOptions) *SignupService {
 // Register concurrently executes a list of tasks. Completion of tasks are not dependent on each other.
 func (sc *SignupService) register(ctx context.Context, su Signup) error {
 	// TODO: Create specific errors for each handler
-	sc.attachZoomMeetingID(&su)
-	err := sc.zoomService.run(ctx, &su)
+	err := sc.attachZoomMeetingID(&su)
+	if err != nil {
+		return fmt.Errorf("attachZoomMeetingID: %w", err)
+	}
+	err = sc.zoomService.run(ctx, &su)
 	if err != nil {
 		return fmt.Errorf("zoomService.run: %w", err)
 	}
@@ -324,7 +327,7 @@ func (sc *SignupService) register(ctx context.Context, su Signup) error {
 		}(task)
 	}
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("errorGroup: %v", err)
+		return err
 	}
 	return nil
 }

--- a/signup_test.go
+++ b/signup_test.go
@@ -48,6 +48,7 @@ func TestRegisterUser(t *testing.T) {
 			Cell:             "555-123-4567",
 			Referrer:         "instagram",
 			ReferrerResponse: "",
+			StartDateTime:    mustMakeTime(t, time.RFC822, "16 Nov 22 18:00 UTC"), // 12 central
 		}
 
 		mailService := &MockMailgunService{
@@ -61,6 +62,8 @@ func TestRegisterUser(t *testing.T) {
 		signupService := newSignupService(signupServiceOptions{
 			tasks:       []Task{mailService},
 			zoomService: zoomService,
+			// zoom meeting id for 12 central
+			meetings: map[int]string{12: "983782"},
 		})
 
 		err := signupService.register(context.Background(), signup)


### PR DESCRIPTION
If an Info Session time does not have a corresponding Zoom Meeting ID, the registrants POST request was sent anyway:

#### Example Zoom API Error:
```
problem signing user up: zoomService.run: HTTP Error:
POST: https://api.zoom.us
/v2/meetings/0/registrants?occurrence_id=1669046400000
Response:
404 Not Found
Meeting is not found or has expired.

Signup:
"Henri"
"Testaroni"
"[email redacted]"
"[cell redacted]"
"21 Nov 22 10:00 CST"
"TNhqqs226hAnDok72"
```

We have a guard to prevent sending the request if there was no meeting ID, but forgot to check the resulting `err`. This PR adds that check and returns before calling the Zoom API. 
#### New error:
```
problem signing user up: attachZoomMeetingID: no zoom meeting found with start hour: 10

Signup:
"Henri"
"Testaroni"
"[email redacted]"
"[cell redacted]"
"21 Nov 22 10:00 CST"
"TNhqqs226hAnDok72"
```