### PR TITLE
Support UserLocations

### DIFF
--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "testing"
-      - "fix/none-of-these"
+      - "feat/user-location"
 
 jobs:
   build-deploy-cloud-function:

--- a/greenlight_test.go
+++ b/greenlight_test.go
@@ -19,23 +19,24 @@ func TestPostWebhook(t *testing.T) {
 			NameFirst:        "Bob",
 			NameLast:         "Ross",
 			Email:            "bross@pbs.org",
-			Cell:             `json:"cell" schema:"cell"`,
+			Cell:             "555-123-4567",
 			Referrer:         "instagram",
 			ReferrerResponse: "",
 			StartDateTime:    sessionStartDate,
 			Cohort:           "is-mar-14-22-12pm",
 			SessionID:        "X5TsABhN94yesyMEi",
+			UserLocation:     "Louisiana",
 		}
 		mockGreenlightSvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Sends API Key header
 			assertEqual(t, r.Header.Get("X-Greenlight-Signup-Api-Key"), apiKey)
 
 			// POSTs correct JSON body
-			var resp Signup
+			var glReq Signup
 			d := json.NewDecoder(r.Body)
-			d.Decode(&resp)
+			d.Decode(&glReq)
 
-			assertDeepEqual(t, resp, su)
+			assertDeepEqual(t, glReq, su)
 		}))
 
 		glSvc := NewGreenlightService(mockGreenlightSvr.URL, apiKey)

--- a/signup.go
+++ b/signup.go
@@ -42,6 +42,7 @@ type (
 		// TODO: make LocationType an enum
 		LocationType   string      `json:"locationType" schema:"locationType"`
 		GooglePlace    GooglePlace `json:"googlePlace" schema:"googlePlace"`
+		UserLocation   string      `json:"userLocation" schema:"userLocation"`
 		zoomMeetingID  int64
 		zoomMeetingURL string
 	}


### PR DESCRIPTION
Partially resolves:
https://github.com/OperationSpark/service-signups/issues/35

- Add support for `UserLocation` string field.
- Send `userLocation` to Greenlight
- https://github.com/OperationSpark/greenlight-v2/pull/1135
- https://github.com/OperationSpark/operationspark-org-website-2022/pull/48