### PR TITLE
Use global zoomCreds variable

### DIFF
--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "testing"
-      - "feat/info-session-notifications"
+      - "feat/global-zoom-token"
 
 jobs:
   build-deploy-cloud-function:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-62.9%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-63.0%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/zoom.go
+++ b/zoom.go
@@ -12,6 +12,10 @@ import (
 	"github.com/operationspark/service-signup/zoom/meeting"
 )
 
+// Using global variable to share token across invocations.
+// https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations
+var zoomCreds tokenResponse
+
 type (
 	zoomService struct {
 		// Base API endpoint. Default: "https://api.zoom.us/v2"
@@ -20,12 +24,10 @@ type (
 		oauthURL string
 		// HTTP client for making Zoom API requests.
 		// https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#overview
-		client         http.Client
-		accessToken    string
-		tokenExpiresAt time.Time
-		accountID      string
-		clientID       string
-		clientSecret   string
+		client       http.Client
+		accountID    string
+		clientID     string
+		clientSecret string
 	}
 
 	tokenResponse struct {
@@ -33,6 +35,8 @@ type (
 		ExpiresIn   int    `json:"expires_in"`
 		Scope       string `json:"scope"`
 		TokenType   string `json:"token_type"`
+		// Calculated from ExpiresIn
+		ExpiresAt time.Time
 	}
 
 	ZoomOptions struct {
@@ -83,10 +87,12 @@ func (z *zoomService) name() string {
 // RegisterUser creates and submits a user's registration to a meeting. The specific meeting is decided from the Signup's startDateTime.
 func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 	// Authenticate client
-	if !z.isAuthenticated() {
-		if err := z.authenticate(ctx); err != nil {
+	if !z.isAuthenticated(zoomCreds) {
+		token, err := z.authenticate(ctx)
+		if err != nil {
 			return fmt.Errorf("authenticate: %w", err)
 		}
+		zoomCreds = token
 	}
 
 	// Send Zoom API req to register user to meeting
@@ -118,7 +124,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 		return fmt.Errorf("newRequestWithContext: %w", err)
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", z.accessToken))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", zoomCreds.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := z.client.Do(req)
@@ -142,7 +148,7 @@ func (z *zoomService) registerUser(ctx context.Context, su *Signup) error {
 }
 
 // Authenticate requests an access token and sets it along with the expiration date on the service.
-func (z *zoomService) authenticate(ctx context.Context) error {
+func (z *zoomService) authenticate(ctx context.Context) (tokenResponse, error) {
 	url := fmt.Sprintf("%s/token?grant_type=account_credentials&account_id=%s", z.oauthURL, z.accountID)
 	// Make a HTTP req to authenticate the client
 	req, err := http.NewRequestWithContext(
@@ -152,35 +158,41 @@ func (z *zoomService) authenticate(ctx context.Context) error {
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("NewRequestWithContext: %w", err)
+		return tokenResponse{}, fmt.Errorf("NewRequestWithContext: %w", err)
 	}
 
 	req.Header.Add("Authorization", "Basic "+z.encodeCredentials())
 
 	resp, err := z.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("client.do: %w", err)
+		return tokenResponse{}, fmt.Errorf("client.do: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
-		return handleHTTPError(resp)
+		return tokenResponse{}, handleHTTPError(resp)
 	}
 
 	var body tokenResponse
 	d := json.NewDecoder(resp.Body)
 	err = d.Decode(&body)
 	if err != nil {
-		return fmt.Errorf("decode: %w", err)
+		return tokenResponse{}, fmt.Errorf("decode: %w", err)
 	}
 
-	z.accessToken = body.AccessToken
-	z.tokenExpiresAt = time.Now().Add(time.Second * time.Duration(body.ExpiresIn))
-	return nil
+	creds := tokenResponse{
+		AccessToken: body.AccessToken,
+		ExpiresIn:   body.ExpiresIn,
+		ExpiresAt:   time.Now().Add(time.Second * time.Duration(body.ExpiresIn)),
+	}
+
+	return creds, nil
 }
 
-func (z *zoomService) isAuthenticated() bool {
-	return len(z.accessToken) > 0 &&
-		time.Now().Before(z.tokenExpiresAt.Truncate(time.Minute))
+func (z *zoomService) isAuthenticated(creds tokenResponse) bool {
+	// Shave 5 min off expiration date as a buffer to request a new token
+	expirationDate := creds.ExpiresAt.Add(time.Minute * -5)
+	return len(creds.AccessToken) > 0 &&
+		time.Now().Before(expirationDate)
 }
 
 // EncodeCredentials base64 encodes the client ID and secret, separated by a colon.

--- a/zoom_test.go
+++ b/zoom_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,19 +92,20 @@ func TestAuthenticate(t *testing.T) {
 			clientSecret:      fakeClientSecret,
 			accountID:         fakeAccountID,
 		})
-		err := zsvc.authenticate(context.Background())
+
+		token, err := zsvc.authenticate(context.Background())
 		if err != nil {
 			t.Fatalf("authenticate: %v", err)
 		}
 
-		assertEqual(t, zsvc.accessToken, fakeAccessToken)
+		assertEqual(t, token.AccessToken, fakeAccessToken)
 		// token expiration date should be now() + expiresIn
 		wantExpiry := time.Now().
 			Add(time.Second * time.Duration(expiresIn)).
 			// Round down to the nearest minute
 			Truncate(time.Minute)
 
-		gotExpiry := zsvc.tokenExpiresAt.Truncate(time.Minute)
+		gotExpiry := token.ExpiresAt.Truncate(time.Minute)
 		assertEqual(t, gotExpiry, wantExpiry)
 	})
 }
@@ -111,22 +113,23 @@ func TestAuthenticate(t *testing.T) {
 func TestIsAuthenticated(t *testing.T) {
 	t.Run("returns false if the client has no token", func(t *testing.T) {
 		zsvc := NewZoomService(ZoomOptions{})
-		assertEqual(t, zsvc.isAuthenticated(), false)
+		assertEqual(t, zsvc.isAuthenticated(tokenResponse{}), false)
 	})
 
 	t.Run("returns false if the client's token is expired", func(t *testing.T) {
 		zsvc := NewZoomService(ZoomOptions{})
-		zsvc.tokenExpiresAt = time.Now().Add(-time.Minute)
+		tokenExpiresAt := time.Now().Add(-time.Minute)
 
-		assertEqual(t, zsvc.isAuthenticated(), false)
+		assertEqual(t, zsvc.isAuthenticated(tokenResponse{ExpiresAt: tokenExpiresAt}), false)
 	})
 
 	t.Run("returns true if the client has an unexpired token", func(t *testing.T) {
 		zsvc := NewZoomService(ZoomOptions{})
-		zsvc.accessToken = "an-access-token"
-		zsvc.tokenExpiresAt = time.Now().Add(time.Minute * 1)
 
-		assertEqual(t, zsvc.isAuthenticated(), true)
+		assertEqual(t, zsvc.isAuthenticated(tokenResponse{
+			AccessToken: "an-access-token",
+			ExpiresAt:   time.Now().Add(time.Minute * 10),
+		}), true)
 	})
 }
 
@@ -144,44 +147,56 @@ func TestRegisterForMeeting(t *testing.T) {
 	// Simulate the registrant-specific Join URL
 	// Regular Zoom links, (Ex: https://us06web.zoom.us/j/87582741258), will redirect an unauthorized user to the registration page, defeating the purpose of auto-registration.
 	mockJoinURL := fmt.Sprintf("https://us06web.zoom.us/w/%d?tk=6ySWiEckpHMI15UYaou_2dkNdDxTHbx7LM8l73iT7rM.DQMAAAAUeoDxnxZ5HSAGdi4newfHJJB#NBDETFhraE1BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", mockMeetingID)
+	accessToken := "fake_access_token"
 
 	mockZoomServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/token") {
+			e := json.NewEncoder(w)
+			err := e.Encode(tokenResponse{
+				AccessToken: accessToken,
+				ExpiresIn:   3600, // one hour in secs
+			})
+			assertNilError(t, err)
+			return
+		}
 
-		assertEqual(t, r.Method, http.MethodPost)
-		// Check auth token
-		authHeader := r.Header.Get("Authorization")
-		assertEqual(t, authHeader, "Bearer fake_access_token")
+		if strings.Contains(r.URL.Path, "/meetings") {
+			assertEqual(t, r.Method, http.MethodPost)
+			// Check auth token
+			authHeader := r.Header.Get("Authorization")
+			assertEqual(t, authHeader, "Bearer fake_access_token")
 
-		assertEqual(t, r.URL.Path, fmt.Sprintf("/meetings/%d/registrants", mockMeetingID))
-		// Meeting Occurrence ID. Provide this field to view meeting details of a particular occurrence of the recurring meeting.
-		assertEqual(t, r.URL.Query().Get("occurrence_id"), "1666045800000")
+			assertEqual(t, r.URL.Path, fmt.Sprintf("/meetings/%d/registrants", mockMeetingID))
+			// Meeting Occurrence ID. Provide this field to view meeting details of a particular occurrence of the recurring meeting.
+			assertEqual(t, r.URL.Query().Get("occurrence_id"), "1666045800000")
 
-		var reqBody meeting.RegistrantRequest
+			var reqBody meeting.RegistrantRequest
 
-		d := json.NewDecoder(r.Body)
-		err := d.Decode(&reqBody)
-		require.NoError(t, err)
+			d := json.NewDecoder(r.Body)
+			err := d.Decode(&reqBody)
+			require.NoError(t, err)
 
-		assertEqual(t, reqBody.Email, su.Email)
-		assertEqual(t, reqBody.FirstName, su.NameFirst)
-		assertEqual(t, reqBody.LastName, su.NameLast)
+			assertEqual(t, reqBody.Email, su.Email)
+			assertEqual(t, reqBody.FirstName, su.NameFirst)
+			assertEqual(t, reqBody.LastName, su.NameLast)
 
-		w.WriteHeader(http.StatusOK)
-		e := json.NewEncoder(w)
-		// Respond with the Join URL
-		err = e.Encode(meeting.RegistrationResponse{
-			JoinURL: mockJoinURL,
-		})
-		require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			e := json.NewEncoder(w)
+			// Respond with the Join URL
+			err = e.Encode(meeting.RegistrationResponse{
+				JoinURL: mockJoinURL,
+			})
+			require.NoError(t, err)
+			return
+		}
+
+		http.Error(w, fmt.Sprintf("invalid URL:\n%q", r.URL.Path), http.StatusMethodNotAllowed)
 	}))
 
 	zsvc := NewZoomService(ZoomOptions{
-		baseAPIOverride: mockZoomServer.URL,
+		baseAPIOverride:   mockZoomServer.URL,
+		baseOAuthOverride: mockZoomServer.URL,
 	})
-
-	// Fake authentication
-	zsvc.accessToken = "fake_access_token"
-	zsvc.tokenExpiresAt = time.Now().Add(time.Minute * 10)
 
 	// Method under test
 	err := zsvc.registerUser(context.Background(), &su)


### PR DESCRIPTION
Attempt to resolve the following error:
### Error:
``` 
POST: https://api.zoom.us
 /v2/meetings/[redacted]/registrants?occurrence_id=1673287200000
 Response:
 Signup:
 401 Unauthorized
 ```
 
 #### Description
When a person signs up, the service authenticates with the Zoom API and receives an access token. I believe when multiple requests come in quick succession, the previous token is invalidated.

Ex:
```
clientA -> authenticate
token 12345 <- Zoom API

clientB -> authenticate
token 98876 <- Zoom API

token 12345 is no longer valid
```
The solution is to set the token in the global space and share the token state over subsequent invocations.
https://cloud.google.com/functions/docs/bestpractices/tips#use_global_variables_to_reuse_objects_in_future_invocations