### PR TITLE
Hardcode SMS Renderer URL. Remove associated variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,4 +29,4 @@ TWILIO_CONVERSATIONS_SID="[Twilio Conversations SID]"
 
 URL_SHORTENER_API_KEY="[Operation Spark URL Shortener API Key]"
 
-OS_MESSAGING_SERVICE_URL="[Operation Spark Message Rendering Service URL]"
+OS_MESSAGING_SERVICE_URL="[Operation Spark Messenger Service URL (e.g. https://messenger.operationspark.org)]"

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "testing"
-      - "fix/zoom-auth"
+      - "fix/notification-reminder-link "
 
 jobs:
   build-deploy-cloud-function:
@@ -47,7 +47,6 @@ jobs:
             TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
             URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
             OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
-            OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             MONGO_URI=${{secrets.MONGO_URI}},
             APP_ENV=testing
       - id: "trigger-url"

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - "testing"
-      - "fix/notification-reminder-link "
+      - "fix/notification-reminder-link"
 
 jobs:
   build-deploy-cloud-function:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,6 @@ jobs:
             TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
             URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
             OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
-            OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             MONGO_URI=${{secrets.MONGO_URI}}
       - id: "trigger-url"
         run: 'echo "${{ steps.deploy.outputs.url }}"'

--- a/function.go
+++ b/function.go
@@ -64,10 +64,11 @@ func NewNotifyServer() *notify.Server {
 
 	// TODO: Should we just use the once instance of a Twilio service?
 	twilioSvc := NewTwilioService(twilioServiceOptions{
-		accountSID:       os.Getenv("TWILIO_ACCOUNT_SID"),
-		authToken:        os.Getenv("TWILIO_AUTH_TOKEN"),
-		fromPhoneNum:     os.Getenv("TWILIO_PHONE_NUMBER"),
-		conversationsSid: os.Getenv("TWILIO_CONVERSATIONS_SID"),
+		accountSID:                 os.Getenv("TWILIO_ACCOUNT_SID"),
+		authToken:                  os.Getenv("TWILIO_AUTH_TOKEN"),
+		fromPhoneNum:               os.Getenv("TWILIO_PHONE_NUMBER"),
+		conversationsSid:           os.Getenv("TWILIO_CONVERSATIONS_SID"),
+		opSparkMessagingSvcBaseURL: os.Getenv("OS_MESSAGING_SERVICE_URL"),
 	})
 
 	return notify.NewServer(notify.ServerOpts{
@@ -109,14 +110,12 @@ func NewSignupServer() *signupServer {
 	twilioConversationsSid := os.Getenv("TWILIO_CONVERSATIONS_SID")
 
 	osMessagingSvcURL := os.Getenv("OS_MESSAGING_SERVICE_URL")
-	osRenderingSvcURL := os.Getenv("OS_RENDERING_SERVICE_URL")
 
 	twilioSvc := NewTwilioService(twilioServiceOptions{
 		accountSID:                 twilioAcctSID,
 		authToken:                  twilioAuthToken,
 		fromPhoneNum:               twilioPhoneNum,
 		opSparkMessagingSvcBaseURL: osMessagingSvcURL,
-		opSparkRenderingSvcBaseUrl: osRenderingSvcURL,
 		conversationsSid:           twilioConversationsSid,
 	})
 

--- a/signup.go
+++ b/signup.go
@@ -231,7 +231,7 @@ func (su Signup) shortMessage(infoURL string) (string, error) {
 
 // ShortMessagingURL produces a custom URL for use on Operation Spark's SMS Messaging Preview service.
 // https://github.com/OperationSpark/sms.opspark.org
-func (su Signup) shortMessagingURL(baseURL string) (string, error) {
+func (su Signup) shortMessagingURL() (string, error) {
 	line1, cityStateZip := greenlight.ParseAddress(su.GooglePlace.Address)
 
 	p := messagingReqParams{
@@ -251,9 +251,8 @@ func (su Signup) shortMessagingURL(baseURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("structToBase64: %w", err)
 	}
-	if baseURL == "" {
-		baseURL = "https://sms.operationspark.org"
-	}
+
+	baseURL := "https://sms.operationspark.org"
 	return fmt.Sprintf("%s/m/%s", baseURL, encoded), nil
 }
 

--- a/signup_test.go
+++ b/signup_test.go
@@ -578,10 +578,10 @@ func TestShortMessagingURL(t *testing.T) {
 			},
 		}
 
-		wantURLPrefix := "https://sms.opspark.org/m/"
+		wantURLPrefix := "https://sms.operationspark.org/m/"
 
 		// method under test
-		gotURL, err := s.shortMessagingURL("https://sms.opspark.org")
+		gotURL, err := s.shortMessagingURL()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Since the renderer service was split from the Messenger service, it will remain the same across all environments. With this change, we can hardcode the Renderer Service API URL to cut down on confusion between the Renderer and Messenger URLs.