### PR TITLE
Update rendering service types/vars

### DIFF
--- a/.github/workflows/signup-smoke.yml
+++ b/.github/workflows/signup-smoke.yml
@@ -15,6 +15,7 @@ jobs:
     environment: production
     env:
       GCP_SA_CREDS_JSON: ${{secrets.GCP_SA_CREDS_JSON}}
+      SMOKE_LIVE: "true"
       TEST_TO_EMAIL: ${{secrets.TEST_TO_EMAIL}}
       TEST_TO_NUM: ${{secrets.TEST_TO_NUM}}
       TWILIO_ACCOUNT_SID: ${{secrets.TWILIO_ACCOUNT_SID}}

--- a/cmd/smoke/smoke_test.go
+++ b/cmd/smoke/smoke_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -134,8 +136,12 @@ func TestCheckInfoPageContent(t *testing.T) {
 	})
 }
 
-// CheckTestsEnabled checks we're on the "CI" workflow. If so, returns false, otherwise returns true. We only want these tests to run after a successful deployment.
+// CheckTestsEnabled checks if the 'SMOKE_LIVE' env var is explicitly set to "true". If so, returns true, otherwise returns false. We only want these tests to run after a successful deployment.
 func checkTestsEnabled() bool {
-	workflowName := os.Getenv("GITHUB_WORKFLOW")
-	return strings.ToUpper(workflowName) != "CI"
+	isSmokeLive, err := strconv.ParseBool(os.Getenv("SMOKE_LIVE"))
+	if err != nil {
+		fmt.Println("could not parse 'SMOKE_LIVE' env var")
+		return false
+	}
+	return isSmokeLive
 }

--- a/function.go
+++ b/function.go
@@ -72,10 +72,10 @@ func NewNotifyServer() *notify.Server {
 	})
 
 	return notify.NewServer(notify.ServerOpts{
-		OSMessagingService: &osMessenger{baseURL: os.Getenv("OS_MESSAGING_SERVICE_URL")},
-		Store:              mongoService,
-		SMSService:         twilioSvc,
-		ShortLinkService:   NewURLShortener(ShortenerOpts{apiKey: os.Getenv("URL_SHORTENER_API_KEY")}),
+		OSRendererService: &osRenderer{baseURL: os.Getenv("OS_RENDERING_SERVICE_URL")},
+		Store:             mongoService,
+		SMSService:        twilioSvc,
+		ShortLinkService:  NewURLShortener(ShortenerOpts{apiKey: os.Getenv("URL_SHORTENER_API_KEY")}),
 	})
 }
 

--- a/notify/info_session.go
+++ b/notify/info_session.go
@@ -51,7 +51,8 @@ type (
 		client *mongo.Client
 	}
 
-	OSMessenger interface {
+	OSRenderer interface {
+		// CreateMessageURL creates a URL to the Operation Spark Message Template Renderer with URL encoded data.
 		CreateMessageURL(Participant) (string, error)
 	}
 
@@ -64,10 +65,10 @@ type (
 	}
 
 	ServerOpts struct {
-		OSMessagingService OSMessenger
-		ShortLinkService   Shortener
-		SMSService         SMSSender
-		Store              Store
+		OSRendererService OSRenderer
+		ShortLinkService  Shortener
+		SMSService        SMSSender
+		Store             Store
 	}
 
 	SMSSender interface {
@@ -76,7 +77,7 @@ type (
 	}
 
 	Server struct {
-		osMsSvc       OSMessenger
+		osMsSvc       OSRenderer
 		shortySrv     Shortener
 		store         Store
 		twilioService SMSSender
@@ -108,7 +109,7 @@ const (
 
 func NewServer(o ServerOpts) *Server {
 	return &Server{
-		osMsSvc:       o.OSMessagingService,
+		osMsSvc:       o.OSRendererService,
 		shortySrv:     o.ShortLinkService,
 		store:         o.Store,
 		twilioService: o.SMSService,

--- a/notify/info_session_test.go
+++ b/notify/info_session_test.go
@@ -25,7 +25,7 @@ type (
 		calledWith []string
 	}
 
-	MockOSMessenger struct{}
+	MockOSRenderer  struct{}
 	MockShortLinker struct{}
 )
 
@@ -39,7 +39,7 @@ func (m *MockSMSService) FormatCell(cell string) string {
 	return "+1" + strings.ReplaceAll(cell, "-", "")
 }
 
-func (m MockOSMessenger) CreateMessageURL(Participant) (string, error) {
+func (m MockOSRenderer) CreateMessageURL(Participant) (string, error) {
 	return "", nil
 }
 
@@ -222,10 +222,10 @@ func TestServer(t *testing.T) {
 		mockTwilio := MockSMSService{}
 
 		srv := NewServer(ServerOpts{
-			OSMessagingService: MockOSMessenger{},
-			ShortLinkService:   MockShortLinker{},
-			Store:              mongoService,
-			SMSService:         &mockTwilio,
+			OSRendererService: MockOSRenderer{},
+			ShortLinkService:  MockShortLinker{},
+			Store:             mongoService,
+			SMSService:        &mockTwilio,
 		})
 
 		srv.ServeHTTP(resp, req)

--- a/signup.go
+++ b/signup.go
@@ -94,30 +94,31 @@ type (
 		MapURL       string `json:"mapUrl"`
 	}
 
-	// Request params for the Operation Spark messaging service.
-	messagingReqParams struct {
-		Template     osMessengerTemplate `json:"template"`
-		ZoomLink     string              `json:"zoomLink"`
-		Date         time.Time           `json:"date"`
-		Name         string              `json:"name"`
-		LocationType string              `json:"locationType"`
-		Location     Location            `json:"location"`
+	// Request params for the Operation Spark Message Template Renderer service.
+	rendererReqParams struct {
+		Template     osRendererTemplate `json:"template"`
+		ZoomLink     string             `json:"zoomLink"`
+		Date         time.Time          `json:"date"`
+		Name         string             `json:"name"`
+		LocationType string             `json:"locationType"`
+		Location     Location           `json:"location"`
 	}
 
-	osMessenger struct {
-		// OpSpark Messaging Service base URL.
+	osRenderer struct {
+		// OpSpark Message Template Renderer Service base URL.
+		// Defaults to https://sms.operationspark.org
 		baseURL string
 	}
 
-	osMessengerTemplate string
+	osRendererTemplate string
 )
 
 const (
-	INFO_SESSION_TEMPLATE osMessengerTemplate = "InfoSession"
+	INFO_SESSION_TEMPLATE osRendererTemplate = "InfoSession"
 )
 
 // StructToBase64 marshals a struct to JSON then encodes the string to base64.
-func (m *messagingReqParams) toBase64() (string, error) {
+func (m *rendererReqParams) toBase64() (string, error) {
 	j, err := json.Marshal(m)
 	if err != nil {
 		return "", fmt.Errorf("marshall: %w", err)
@@ -127,7 +128,7 @@ func (m *messagingReqParams) toBase64() (string, error) {
 }
 
 // FromBase64 decodes a base64 string into a messagingReqParams struct.
-func (m *messagingReqParams) fromBase64(encoded string) error {
+func (m *rendererReqParams) fromBase64(encoded string) error {
 	jsonBytes, err := base64.URLEncoding.DecodeString(encoded)
 	if err != nil {
 		return err
@@ -235,7 +236,7 @@ func (su Signup) shortMessage(infoURL string) (string, error) {
 func (su Signup) shortMessagingURL() (string, error) {
 	line1, cityStateZip := greenlight.ParseAddress(su.GooglePlace.Address)
 
-	p := messagingReqParams{
+	p := rendererReqParams{
 		Template:     INFO_SESSION_TEMPLATE,
 		ZoomLink:     su.zoomMeetingURL,
 		Date:         su.StartDateTime,
@@ -333,8 +334,8 @@ func (sc *SignupService) attachZoomMeetingID(su *Signup) error {
 	return nil
 }
 
-func (osm *osMessenger) CreateMessageURL(p notify.Participant) (string, error) {
-	params := messagingReqParams{
+func (osm *osRenderer) CreateMessageURL(p notify.Participant) (string, error) {
+	params := rendererReqParams{
 		Template:     INFO_SESSION_TEMPLATE,
 		ZoomLink:     p.ZoomJoinURL,
 		Name:         p.NameFirst,

--- a/signup_test.go
+++ b/signup_test.go
@@ -403,7 +403,7 @@ https://oprk.org/kRds5MKvKI`
 
 func TestStructToBase64(t *testing.T) {
 	t.Run("serializes a struct to base 64 encoding", func(t *testing.T) {
-		params := messagingReqParams{
+		params := rendererReqParams{
 			Template:     "InfoSession",
 			ZoomLink:     "https://us06web.zoom.us/j/12345678910",
 			Date:         mustMakeTime(t, time.RFC3339, "2022-10-05T17:00:00.000Z"),
@@ -430,7 +430,7 @@ func TestStructToBase64(t *testing.T) {
 
 func TestFromBase64(t *testing.T) {
 	t.Run("decodes", func(t *testing.T) {
-		wantParams := messagingReqParams{
+		wantParams := rendererReqParams{
 			Template:     "InfoSession",
 			ZoomLink:     "https://us06web.zoom.us/j/12345678910",
 			Date:         mustMakeTime(t, "January 02, 2006 3pm MST", "December 25, 2022 1pm CST"),
@@ -449,7 +449,7 @@ func TestFromBase64(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var gotParams messagingReqParams
+		var gotParams rendererReqParams
 
 		err = gotParams.fromBase64(encoded)
 		if err != nil {
@@ -469,7 +469,7 @@ func TestFromBase64(t *testing.T) {
 	})
 
 	t.Run("decodes pre-encoded info session details link", func(t *testing.T) {
-		var params messagingReqParams
+		var params rendererReqParams
 
 		err := params.fromBase64("eyJ0ZW1wbGF0ZSI6IkluZm9TZXNzaW9uIiwiem9vbUxpbmsiOiJodHRwczovL3VzMDZ3ZWIuem9vbS51cy9qLzEyMzQ1Njc4OTEwIiwiZGF0ZSI6IjIwMjItMTAtMDVUMTc6MDA6MDAuMDAwWiIsIm5hbWUiOiJGaXJzdE5hbWUiLCJsb2NhdGlvblR5cGUiOiJIWUJSSUQiLCJsb2NhdGlvbiI6eyJuYW1lIjoiU29tZSBQbGFjZSIsImxpbmUxIjoiMTIzIE1haW4gU3QiLCJjaXR5U3RhdGVaaXAiOiJDaXR5LCBTdGF0ZSAxMjM0NSIsIm1hcFVybCI6Imh0dHBzOi8vd3d3Lmdvb2dsZS5jb20vbWFwcy9wbGFjZS8xMjMrTWFpbitTdCwrQ2l0eSwrU3RhdGUrMTIzNDUifX0=")
 
@@ -596,7 +596,7 @@ func TestShortMessagingURL(t *testing.T) {
 		encoded := strings.TrimPrefix(gotURL, wantURLPrefix)
 
 		// decode the params
-		var gotParams messagingReqParams
+		var gotParams rendererReqParams
 		err = gotParams.fromBase64(encoded)
 		if err != nil {
 			t.Fatal(err)
@@ -626,7 +626,7 @@ func TestCreateMessageURL(t *testing.T) {
 			MapURL:       "https://testmapurl.google.com",
 		}
 
-		m := osMessenger{}
+		r := osRenderer{}
 		person := gofakeit.Person()
 		p := notify.Participant{
 			NameFirst:           person.FirstName,
@@ -639,7 +639,7 @@ func TestCreateMessageURL(t *testing.T) {
 			SessionLocationType: "HYBRID",
 			SessionLocation:     notify.Location(osLoc),
 		}
-		msgURL, err := m.CreateMessageURL(p)
+		msgURL, err := r.CreateMessageURL(p)
 		require.NoError(t, err)
 		// Make sure location data is encoded in the URL
 		u, err := url.Parse(msgURL)
@@ -654,7 +654,7 @@ func TestCreateMessageURL(t *testing.T) {
 		require.NoError(t, err)
 
 		// Unmarshal the decoded JSON into a messaging request params struct
-		var params messagingReqParams
+		var params rendererReqParams
 		jd := json.NewDecoder(bytes.NewReader(decodedJson))
 		err = jd.Decode(&params)
 		require.NoError(t, err)
@@ -682,8 +682,8 @@ func TestCreateMessageURL(t *testing.T) {
 			SessionLocation: notify.Location{},
 		}
 
-		m := osMessenger{}
-		msgURL, err := m.CreateMessageURL(p)
+		r := osRenderer{}
+		msgURL, err := r.CreateMessageURL(p)
 		require.NoError(t, err)
 		// Make sure location data is encoded in the URL
 		u, err := url.Parse(msgURL)


### PR DESCRIPTION
The main issue is that we're using the wrong env var here: 
https://github.com/OperationSpark/service-signups/pull/52/files#diff-323d89938d680c0b70940a4baf907cadf4c13e36f1bb20514a2a79cc2ff86eabR75
The Info Message URLs sent to students have the wrong host, `messenger.operationspark.org`, where it should be `sms.operationspark.org`.

Since splitting out the Operation Spark [Messenger](https://messenger.operationspark.org/conversations/0) app and the [Message Template Renderer](https://sms.operationspark.org/), using 'messaging' in variable names became too ambiguous. 
This PR hopes to be more specific with which app the variables are referring to.

