### PR TITLE
add `OS_RENDERING_SERVICE_URL` to workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,6 +45,8 @@ jobs:
             TWILIO_PHONE_NUMBER=${{secrets.TWILIO_PHONE_NUMBER}},
             TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
             URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
+            OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
+            OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             MONGO_URI=${{secrets.MONGO_URI}},
             APP_ENV=staging
       - id: "trigger-url"

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -47,6 +47,7 @@ jobs:
             TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
             URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
             OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
+            OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             MONGO_URI=${{secrets.MONGO_URI}},
             APP_ENV=testing
       - id: "trigger-url"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
             TWILIO_CONVERSATIONS_SID=${{secrets.TWILIO_CONVERSATIONS_SID}},
             URL_SHORTENER_API_KEY=${{secrets.URL_SHORTENER_API_KEY}},
             OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
+            OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             MONGO_URI=${{secrets.MONGO_URI}}
       - id: "trigger-url"
         run: 'echo "${{ steps.deploy.outputs.url }}"'


### PR DESCRIPTION
add `OS_RENDERING_SERVICE_URL` to the github workflow to match [fetched env](https://github.com/OperationSpark/service-signups/blob/main/function.go#L75)