### PR TITLE
add join code to email template and message url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .env
 .env*
-cmd/__debug_bin
+__debug_bin
 cover.out
 .secrets
 creds.json

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -36,14 +36,17 @@ type (
 		fromNum string
 	}
 
+	// represents greenlight open session API response
 	openSession struct {
 		ID           string                 `json:"_id"`
 		Cohort       string                 `json:"cohort"`
 		LocationType string                 `json:"locationType"`
 		GooglePlace  greenlight.GooglePlace `json:"googlePlace"`
-		Private      bool                   `json:"private"`
-		ProgramID    string                 `json:"programId"`
-		Times        struct {
+		// session join code
+		Code      string `json:"code"`
+		Private   bool   `json:"private"`
+		ProgramID string `json:"programId"`
+		Times     struct {
 			Start struct {
 				DateTime time.Time `json:"dateTime"`
 			} `json:"start"`

--- a/cmd/smoke/smoke_test.go
+++ b/cmd/smoke/smoke_test.go
@@ -33,6 +33,7 @@ func TestSmokeSignup(t *testing.T) {
 		Email:             s.toEmail,
 		GooglePlace:       s.selectedSession.GooglePlace,
 		LocationType:      s.selectedSession.LocationType,
+		JoinCode:          s.selectedSession.Code,
 		NameFirst:         "Halle",
 		NameLast:          "Bot",
 		ProgramID:         s.selectedSession.ProgramID,
@@ -82,6 +83,8 @@ func TestSmokeSignup(t *testing.T) {
 		s.selectedSession.Times.Start.DateTime.In(ct).Format("3:00pm (MST)"),
 		// Name
 		su.NameFirst,
+		//xJoin Code
+		s.selectedSession.Code,
 		// TODO: HTML only contains the next props, so "Hello Halle," not rendered yet.
 		// Zoom link
 		"https://us06web.zoom.us/w/8", //...
@@ -139,8 +142,11 @@ func TestCheckInfoPageContent(t *testing.T) {
 // CheckTestsEnabled checks if the 'SMOKE_LIVE' env var is explicitly set to "true". If so, returns true, otherwise returns false. We only want these tests to run after a successful deployment.
 func checkTestsEnabled() bool {
 	isSmokeLive, err := strconv.ParseBool(os.Getenv("SMOKE_LIVE"))
-	if err != nil {
-		fmt.Println("could not parse 'SMOKE_LIVE' env var")
+	if err != nil || !isSmokeLive {
+		if err != nil {
+			fmt.Print("could not parse 'SMOKE_LIVE' env var")
+		}
+		fmt.Println("smoke test skipped.\nSet `SMOKE_LIVE=true` to run smoke test")
 		return false
 	}
 	return isSmokeLive

--- a/mailgun.go
+++ b/mailgun.go
@@ -52,15 +52,12 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 			"lastName":             vars.LastName,
 			"sessionTime":          vars.SessionTime,
 			"sessionDate":          vars.SessionDate,
+			"joinCode":             vars.JoinCode,
 			"zoomURL":              vars.ZoomURL,
 			"locationLine1":        vars.LocationLine1,
 			"locationCityStateZip": vars.LocationCityStateZip,
 			"locationMapUrl":       vars.LocationMapURL,
 		},
-	}
-	// add joinCode to variables if it exists
-	if vars.JoinCode != "" {
-		t.variables["joinCode"] = vars.JoinCode
 	}
 
 	if su.LocationType == "HYBRID" {

--- a/mailgun.go
+++ b/mailgun.go
@@ -56,8 +56,11 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 			"locationLine1":        vars.LocationLine1,
 			"locationCityStateZip": vars.LocationCityStateZip,
 			"locationMapUrl":       vars.LocationMapURL,
-			"joinCode":             vars.JoinCode,
 		},
+	}
+	// add joinCode to variables if it exists
+	if vars.JoinCode != "" {
+		t.variables["joinCode"] = vars.JoinCode
 	}
 
 	if su.LocationType == "HYBRID" {

--- a/mailgun.go
+++ b/mailgun.go
@@ -56,6 +56,7 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 			"locationLine1":        vars.LocationLine1,
 			"locationCityStateZip": vars.LocationCityStateZip,
 			"locationMapUrl":       vars.LocationMapURL,
+			"joinCode":             vars.JoinCode,
 		},
 	}
 

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -24,6 +24,7 @@ func TestSendWelcome(t *testing.T) {
 			ReferrerResponse: "",
 			StartDateTime:    sessionStartDate,
 			Cohort:           "is-mar-14-22-12pm",
+			JoinCode:         "tlav",
 		}
 
 		domain := "test.notarealdomain.org"
@@ -61,6 +62,7 @@ func TestSendWelcome(t *testing.T) {
 
 			assertEqual(t, gotVars.FirstName, form.NameFirst)
 			assertEqual(t, gotVars.LastName, form.NameLast)
+			assertEqual(t, gotVars.JoinCode, form.JoinCode)
 			assertEqual(t, gotVars.SessionDate, "Monday, Mar 14")
 			assertEqual(t, gotVars.SessionTime, "12:00 PM CDT")
 			// TODO: ZoomURL

--- a/signup.go
+++ b/signup.go
@@ -56,6 +56,7 @@ type (
 		LocationLine1        string `json:"locationLine1"`
 		LocationCityStateZip string `json:"locationCityStateZip"`
 		LocationMapURL       string `json:"locationMapUrl"`
+		JoinCode             string `json:"joinCode"`
 	}
 
 	SignupService struct {
@@ -103,6 +104,7 @@ type (
 		Name         string             `json:"name"`
 		LocationType string             `json:"locationType"`
 		Location     Location           `json:"location"`
+		JoinCode     string             `json:"joinCode"`
 	}
 
 	osRenderer struct {
@@ -165,6 +167,7 @@ func (s *Signup) welcomeData() (welcomeVariables, error) {
 		SessionTime:          s.StartDateTime.In(ctz).Format("3:04 PM MST"),
 		SessionDate:          s.StartDateTime.In(ctz).Format("Monday, Jan 02"),
 		ZoomURL:              s.ZoomMeetingURL(),
+		JoinCode:             s.JoinCode,
 		LocationLine1:        line1,
 		LocationCityStateZip: cityStateZip,
 		LocationMapURL:       greenlight.GoogleLocationLink(s.GooglePlace.Address),
@@ -242,6 +245,7 @@ func (su Signup) shortMessagingURL() (string, error) {
 		ZoomLink:     su.zoomMeetingURL,
 		Date:         su.StartDateTime,
 		Name:         su.NameFirst,
+		JoinCode:     su.JoinCode,
 		LocationType: su.LocationType,
 		Location: Location{
 			Name:         su.GooglePlace.Name,

--- a/signup.go
+++ b/signup.go
@@ -25,6 +25,7 @@ type (
 		GooglePlace       greenlight.GooglePlace `json:"googlePlace" schema:"googlePlace"`
 		// Session's set location type. One of "IN_PERSON" | "VIRTUAL" | "IN_PERSON". If the session's location type is "HYBRID", a student can attend "IN_PERSON" or "VIRTUAL"ly.
 		LocationType     string    `json:"locationType" schema:"locationType"`
+		JoinCode         string    `json:"joinCode"`
 		NameFirst        string    `json:"nameFirst" schema:"nameFirst"`
 		NameLast         string    `json:"nameLast" schema:"nameLast"`
 		ProgramID        string    `json:"programId" schema:"programId"`
@@ -161,8 +162,8 @@ func (s *Signup) welcomeData() (welcomeVariables, error) {
 	return welcomeVariables{
 		FirstName:            s.NameFirst,
 		LastName:             s.NameLast,
-		SessionDate:          s.StartDateTime.In(ctz).Format("Monday, Jan 02"),
 		SessionTime:          s.StartDateTime.In(ctz).Format("3:04 PM MST"),
+		SessionDate:          s.StartDateTime.In(ctz).Format("Monday, Jan 02"),
 		ZoomURL:              s.ZoomMeetingURL(),
 		LocationLine1:        line1,
 		LocationCityStateZip: cityStateZip,

--- a/signup.go
+++ b/signup.go
@@ -25,7 +25,7 @@ type (
 		GooglePlace       greenlight.GooglePlace `json:"googlePlace" schema:"googlePlace"`
 		// Session's set location type. One of "IN_PERSON" | "VIRTUAL" | "IN_PERSON". If the session's location type is "HYBRID", a student can attend "IN_PERSON" or "VIRTUAL"ly.
 		LocationType     string    `json:"locationType" schema:"locationType"`
-		JoinCode         string    `json:"joinCode"`
+		JoinCode         string    `json:"joinCode,omitempty"`
 		NameFirst        string    `json:"nameFirst" schema:"nameFirst"`
 		NameLast         string    `json:"nameLast" schema:"nameLast"`
 		ProgramID        string    `json:"programId" schema:"programId"`
@@ -56,7 +56,7 @@ type (
 		LocationLine1        string `json:"locationLine1"`
 		LocationCityStateZip string `json:"locationCityStateZip"`
 		LocationMapURL       string `json:"locationMapUrl"`
-		JoinCode             string `json:"joinCode"`
+		JoinCode             string `json:"joinCode,omitempty"`
 	}
 
 	SignupService struct {
@@ -104,7 +104,7 @@ type (
 		Name         string             `json:"name"`
 		LocationType string             `json:"locationType"`
 		Location     Location           `json:"location"`
-		JoinCode     string             `json:"joinCode"`
+		JoinCode     string             `json:"joinCode,omitempty"`
 	}
 
 	osRenderer struct {
@@ -246,16 +246,13 @@ func (su Signup) shortMessagingURL() (string, error) {
 		Date:         su.StartDateTime,
 		Name:         su.NameFirst,
 		LocationType: su.LocationType,
+		JoinCode:     su.JoinCode,
 		Location: Location{
 			Name:         su.GooglePlace.Name,
 			Line1:        line1,
 			CityStateZip: cityStateZip,
 			MapURL:       greenlight.GoogleLocationLink(su.GooglePlace.Address),
 		},
-	}
-
-	if su.JoinCode != "" {
-		p.JoinCode = su.JoinCode
 	}
 
 	encoded, err := p.toBase64()

--- a/signup.go
+++ b/signup.go
@@ -245,7 +245,6 @@ func (su Signup) shortMessagingURL() (string, error) {
 		ZoomLink:     su.zoomMeetingURL,
 		Date:         su.StartDateTime,
 		Name:         su.NameFirst,
-		JoinCode:     su.JoinCode,
 		LocationType: su.LocationType,
 		Location: Location{
 			Name:         su.GooglePlace.Name,
@@ -254,6 +253,11 @@ func (su Signup) shortMessagingURL() (string, error) {
 			MapURL:       greenlight.GoogleLocationLink(su.GooglePlace.Address),
 		},
 	}
+
+	if su.JoinCode != "" {
+		p.JoinCode = su.JoinCode
+	}
+
 	encoded, err := p.toBase64()
 	if err != nil {
 		return "", fmt.Errorf("structToBase64: %w", err)


### PR DESCRIPTION
Take the join code sent from the website sign up form and send it along with the other variables for the email template and message url so that students can join the class on greenlight

- send it along to the Renderer URL creator
    - Ex: /m/eyJ0ZW1wbGF0ZSI...
- And a Greenlight link to join the session in the email template
- If no code present, omit the Join URL, from email and renderer URL