### PR TITLE
Add identity value to error

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v1.50.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/notify/info_session.go
+++ b/notify/info_session.go
@@ -167,8 +167,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err = s.sendSMSReminders(ctx, sessions, reqBody.JobArgs.DryRun)
 	if err != nil {
-		fmt.Println("One or more message failed to send", err)
-		http.Error(w, "One or more message failed to send", http.StatusInternalServerError)
+		fmt.Println("One or more messages failed to send", err)
+		http.Error(w, "One or more messages failed to send", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/twilio.go
+++ b/twilio.go
@@ -189,7 +189,7 @@ func (t *smsService) addNumberToConversation(phNum, friendlyName string) (string
 	ppp.SetIdentity(t.conversationsIdentity)
 	_, err = t.client.ConversationsV1.CreateServiceConversationParticipant(t.conversationsSid, *cResp.Sid, ppp)
 	if err != nil {
-		return "", fmt.Errorf("createServiceConversationParticipant with Identity: %w", err)
+		return "", fmt.Errorf("createServiceConversationParticipant with Service Identity: %w: ", err)
 	}
 
 	// Add SMS Recipient to conversation
@@ -201,7 +201,7 @@ func (t *smsService) addNumberToConversation(phNum, friendlyName string) (string
 
 	_, err = t.client.ConversationsV1.CreateServiceConversationParticipant(t.conversationsSid, *cResp.Sid, pp)
 	if err != nil {
-		return "", fmt.Errorf("createServiceConversationParticipant: %w", err)
+		return "", fmt.Errorf("createServiceConversationParticipant: %w\nidentity: %q", err, phNum)
 	}
 
 	return *cResp.Sid, nil


### PR DESCRIPTION
Add more context to these errors:
```
session-signups: One or more messages failed to send addNumberToConversation: createServiceConversationParticipant: Status: 400 - ApiError 50407: Invalid messaging binding address (null) More info: https://www.twilio.com/docs/errors/50407
```