### PR TITLE
checking for invalid phone number error

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package signup
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gorilla/schema"
@@ -51,6 +53,18 @@ func (ss *signupServer) HandleSignUp(w http.ResponseWriter, r *http.Request) {
 	// depending on what we get back, respond accordingly
 	if err != nil {
 		// TODO: handle different kinds of errors differently
+		// handle invalid phone number error
+		if strings.Contains(err.Error(), "invalid number") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, http.StatusBadRequest)
+			fmt.Fprint(w, bytes.NewBufferString(`{
+				"message": "Phone Number Invalid",
+				"field": "phone number"
+			}`))
+			// http.Error(w, "Invalid Phone Number", http.StatusBadRequest)
+			return
+		}
 		fmt.Fprintf(os.Stderr, "\nproblem signing user up: %v\n\n", err)
 		fmt.Printf("Signup:\n%s\n", prettyPrint(su))
 		http.Error(w, "problem signing user up\n", http.StatusInternalServerError)

--- a/twilio.go
+++ b/twilio.go
@@ -32,6 +32,11 @@ type (
 		conversationsIdentity string
 	}
 
+	// error type for invalid phone numbers
+	errInvalidNumber struct {
+		err error
+	}
+
 	twilioServiceOptions struct {
 		accountSID string
 		authToken  string
@@ -51,6 +56,10 @@ type (
 		conversationsIdentity string
 	}
 )
+
+func (e errInvalidNumber) Error() string {
+	return e.err.Error()
+}
 
 func NewTwilioService(o twilioServiceOptions) *smsService {
 	messengerBaseURL := "https://messenger.operationspark.org"
@@ -100,6 +109,12 @@ func (t *smsService) run(ctx context.Context, su Signup) error {
 	if len(existing) == 0 {
 		convoId, err = t.addNumberToConversation(toNum, convoName)
 		if err != nil {
+			twilioInvalidPhoneCode := "50407"
+			// check if error is due to number being invalid, if so use the errInvalidNumber type
+			if strings.Contains(err.Error(), twilioInvalidPhoneCode) {
+				return errInvalidNumber{err: fmt.Errorf("invalid number: %s", toNum)}
+			}
+
 			return fmt.Errorf("addNumberToConversation: %w", err)
 		}
 	} else {


### PR DESCRIPTION
Send back 2 pieces of data when failed
Example: error code: 400 - 500 with an invalid phone number

```
{
  "message": "Phone number invalid",
  "field": "phoneNumber"
}
```