### PR TITLE
Handle SMS opt-in data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-55.2%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-54.7%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/signup.go
+++ b/signup.go
@@ -24,16 +24,18 @@ type (
 		Email             string                 `json:"email" schema:"email"`
 		GooglePlace       greenlight.GooglePlace `json:"googlePlace" schema:"googlePlace"`
 		// Session's set location type. One of "IN_PERSON" | "VIRTUAL" | "IN_PERSON". If the session's location type is "HYBRID", a student can attend "IN_PERSON" or "VIRTUAL"ly.
-		LocationType     string    `json:"locationType" schema:"locationType"`
-		JoinCode         string    `json:"joinCode,omitempty"`
-		NameFirst        string    `json:"nameFirst" schema:"nameFirst"`
-		NameLast         string    `json:"nameLast" schema:"nameLast"`
-		ProgramID        string    `json:"programId" schema:"programId"`
-		Referrer         string    `json:"referrer" schema:"referrer"`
-		ReferrerResponse string    `json:"referrerResponse" schema:"referrerResponse"`
-		SessionID        string    `json:"sessionId" schema:"sessionId"`
-		StartDateTime    time.Time `json:"startDateTime,omitempty" schema:"startDateTime"`
-		Token            string    `json:"token" schema:"token"`
+		LocationType     string `json:"locationType" schema:"locationType"`
+		JoinCode         string `json:"joinCode,omitempty"`
+		NameFirst        string `json:"nameFirst" schema:"nameFirst"`
+		NameLast         string `json:"nameLast" schema:"nameLast"`
+		ProgramID        string `json:"programId" schema:"programId"`
+		Referrer         string `json:"referrer" schema:"referrer"`
+		ReferrerResponse string `json:"referrerResponse" schema:"referrerResponse"`
+		SessionID        string `json:"sessionId" schema:"sessionId"`
+		// If the user has opted-in to receiving text messages.
+		SMSOptIn      bool      `json:"smsOptIn"`
+		StartDateTime time.Time `json:"startDateTime,omitempty" schema:"startDateTime"`
+		Token         string    `json:"token" schema:"token"`
 		// State or country where the person resides.
 		UserLocation   string `json:"userLocation" schema:"userLocation"`
 		zoomMeetingID  int64

--- a/twilio.go
+++ b/twilio.go
@@ -97,6 +97,11 @@ func NewTwilioService(o twilioServiceOptions) *smsService {
 //
 // Note: Twilio has a free Link Shortening service, but it is only available with the Messaging API, not Conversations.
 func (t *smsService) run(ctx context.Context, su Signup) error {
+	if !su.SMSOptIn {
+		fmt.Printf("User opted-out from SMS messages: %s\n", su.String())
+		return nil
+	}
+
 	toNum := t.FormatCell(su.Cell)
 	convoName := fmt.Sprintf("%s %s", su.NameFirst, su.NameLast[0:1])
 	convoId := ""
@@ -120,6 +125,11 @@ func (t *smsService) run(ctx context.Context, su Signup) error {
 	} else {
 		// TODO: Fix this potentially faulty logic if picking the first existing conversation
 		convoId = *existing[0].ConversationSid
+	}
+
+	// Send Opt-in confirmation
+	if err := t.optInConfirmation(ctx, toNum); err != nil {
+		return fmt.Errorf("optInConfirmation: %w", err)
 	}
 
 	// create user-specific info session details URL
@@ -245,6 +255,11 @@ func (t *smsService) sendConvoWebhook(ctx context.Context, convoID string) error
 		return handleHTTPError(resp)
 	}
 	return nil
+}
+
+func (t *smsService) optInConfirmation(ctx context.Context, toNum string) error {
+	msg := "You've opted in for texts from Operation Spark for upcoming sessions. You can text us here if you have further questions. Message and data rates may apply. Reply STOP to unsubscribe."
+	return t.Send(ctx, toNum, msg)
 }
 
 // Send sends an SMS message to the given toNum and returns an error.


### PR DESCRIPTION
Update API to accept `smsOptIn` boolean field on SignUp JSON. 
- If `smsOptIn == false`, we don't send a text via Twilio
- else we send an opt-in confirmation followed up by the rest of the messages:
<img width="599" alt="image" src="https://github.com/OperationSpark/service-signups/assets/9354822/003e85c8-06ee-45bd-a9cb-633b32c8c1c9">


**Note**: Merging this will cause messages to stop sending if the [OS website PR](https://github.com/OperationSpark/operationspark-org-website-2022/pull/94) is not merged as the `smsOptIn` field will default to `false`.
We also need to ensure that the Twilio Messaging Service(s) used by this service is configured to listen for `"STOP"` messages.

