### PR TITLE
Fix Smoke Test

### DIFF
--- a/cmd/smoke/smoke_test.go
+++ b/cmd/smoke/smoke_test.go
@@ -40,6 +40,7 @@ func TestSmokeSignup(t *testing.T) {
 		Referrer:          "verbal",
 		ReferrerResponse:  "Automated Smoke Test",
 		SessionID:         s.selectedSession.ID,
+		SMSOptIn:          true,
 		StartDateTime:     s.selectedSession.Times.Start.DateTime,
 		UserLocation:      "South Dakota",
 	}


### PR DESCRIPTION
Adds `"smsOptIn": true` to the SignUp POST JSON. 

The smoke tests were failing since SMS opt-in defaults to `false` and the SMS was never sent. Then we fetch the last message sent which happened to be from April.


https://github.com/OperationSpark/service-signups/actions/runs/5616235700/job/15236520915#step:4:64
