### PR TITLE
Update Smoke test to support SMS opt-in

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "go.testEnvFile": "${workspaceFolder}/.env.smoke"
+  "go.testEnvFile": "${workspaceFolder}/.env.smoke",
+  "cSpell.words": [
+    "Emptyf",
+    "stretchr"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-54.7%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-54.4%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:


### PR DESCRIPTION
Fixes broken smoke test after merging #68 
Continuation of #69 
Fetches the last two messages from Twilio API, expecting the first to be the opt-in confirmation.
Well, will fetch the last 2. Currently, it only fetches the last message because Twilio is blocking some number of messages until our A2P 10DLC Campaign is approved
![image](https://github.com/OperationSpark/service-signups/assets/9354822/d9332fd2-cffc-4a21-b7fc-fac816616511)
