### PR TITLE
Fix Smoke Test

### DIFF
--- a/cmd/smoke/smoke_test.go
+++ b/cmd/smoke/smoke_test.go
@@ -91,7 +91,7 @@ func TestSmokeSignup(t *testing.T) {
 		// Session Date
 		s.selectedSession.Times.Start.DateTime.In(ct).Format("Monday, January 2, 2006"),
 		// Session Time
-		s.selectedSession.Times.Start.DateTime.In(ct).Format("3:00pm (MST)"),
+		s.selectedSession.Times.Start.DateTime.In(ct).Format("3:04pm (MST)"),
 		// Name
 		su.NameFirst,
 		//xJoin Code


### PR DESCRIPTION
Fix time format for Info Session Start Time target. The target time minutes always resolved to `00`.
https://pkg.go.dev/time#pkg-constants
https://github.com/OperationSpark/service-signups/actions/runs/6318266432/job/17156891565#step:4:64
```
target value "5:00pm (CDT)" not found in Info Page body:
```