### PR TITLE
Move SnapMail Config to entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-56.0%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-55.8%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/function.go
+++ b/function.go
@@ -164,6 +164,7 @@ func NewSignupServer() *signupServer {
 	snapMailURL := os.Getenv("SNAP_MAIL_URL")
 
 	// If we're running in GCP (K_SERVICE env var is set), we can use the GCP Service Account to authenticate with SNAP Mail.
+	// https://cloud.google.com/functions/docs/configuring/env-var#runtime_environment_variables_set_automatically
 	snapMailOptions := []snapMailOption{}
 	if len(os.Getenv("K_SERVICE")) > 0 {
 		client, err := idtoken.NewClient(context.Background(), snapMailURL)

--- a/snapmail.go
+++ b/snapmail.go
@@ -25,8 +25,8 @@ type Payload struct {
 }
 
 type signupEvent struct {
-	Type    string  `json:"eventType"`
-	Payload Payload `json:"payload"`
+	EventType string  `json:"eventType"`
+	Payload   Payload `json:"payload"`
 }
 
 type snapMailOption func(*SnapMail)
@@ -53,7 +53,7 @@ func (sm *SnapMail) name() string {
 
 func (sm *SnapMail) run(ctx context.Context, signup Signup) error {
 	event := signupEvent{
-		Type: "SESSION_SIGNUP",
+		EventType: "SESSION_SIGNUP",
 		Payload: Payload{
 			Email:         signup.Email,
 			NameFirst:     signup.NameFirst,


### PR DESCRIPTION
- Extract `SnapMail` client configuration out of `NewSnapMail` up to entry point (`function.go`)
- Update the SnapMail endpoint to `/events`