### PR TITLE
optional tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-55.8%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-55.5%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/greenlight.go
+++ b/greenlight.go
@@ -24,6 +24,11 @@ func (g greenlightService) run(ctx context.Context, su Signup) error {
 	return g.postWebhook(ctx, su)
 }
 
+// IsRequired return true because the signup record in Greenlight is needed by staff.
+func (g greenlightService) isRequired() bool {
+	return true
+}
+
 func (g greenlightService) name() string {
 	return "greenlight service"
 }

--- a/mailgun.go
+++ b/mailgun.go
@@ -29,6 +29,11 @@ func NewMailgunService(domain, apiKey, baseAPIurlOverride string) *MailgunServic
 	}
 }
 
+// IsRequired returns true because the email needs to be sent to the student to that they can attend the info session.
+func (m MailgunService) isRequired() bool {
+	return true
+}
+
 func (m MailgunService) run(ctx context.Context, su Signup) error {
 	return m.sendWelcome(ctx, su)
 }

--- a/signup.go
+++ b/signup.go
@@ -75,6 +75,8 @@ type (
 		run(ctx context.Context, signup Signup) error
 		// Name Returns the name of the task.
 		name() string
+		// IsRequired determines if the signup request fails when this task fails. If the task is not required and fails, the signup can still succeed.
+		isRequired() bool
 	}
 
 	mutationTask interface {
@@ -306,7 +308,10 @@ func (sc *SignupService) register(ctx context.Context, su Signup) error {
 			g.Go(func() error {
 				err := t.run(ctx, su)
 				if err != nil {
-					return fmt.Errorf("task failed: %q: %v", t.name(), err)
+					if t.isRequired() {
+						return fmt.Errorf("task failed: %q: %w", t.name(), err)
+					}
+					fmt.Printf("task failed: %q: %v", t.name(), err)
 				}
 				return nil
 			})

--- a/slack.go
+++ b/slack.go
@@ -25,7 +25,14 @@ func (sl slackService) name() string {
 }
 
 func NewSlackService(webhookURL string) *slackService {
-	return &slackService{webhookURL}
+	return &slackService{
+		webhookURL: webhookURL,
+	}
+}
+
+// IsRequired returns false because the slack message notification is just nice to have.
+func (sl slackService) isRequired() bool {
+	return false
 }
 
 type message struct {

--- a/snapmail.go
+++ b/snapmail.go
@@ -51,6 +51,11 @@ func (sm *SnapMail) name() string {
 	return "SNAP Mailer"
 }
 
+// IsRequired returns false because the snapMail webhook data can be retrieved from elsewhere and is not required for most students.
+func (sm *SnapMail) isRequired() bool {
+	return false
+}
+
 func (sm *SnapMail) run(ctx context.Context, signup Signup) error {
 	event := signupEvent{
 		EventType: "SESSION_SIGNUP",

--- a/twilio.go
+++ b/twilio.go
@@ -92,6 +92,11 @@ func NewTwilioService(o twilioServiceOptions) *smsService {
 	}
 }
 
+// IsRequired returns true because the SMS message is required to be sent to the student so that they can attend the info session.
+func (s smsService) isRequired() bool {
+	return true
+}
+
 // Run sends an Info Session signup confirmation SMS to the registered participant. We use Twilio's Conversations API instead of the Messaging API to allow multiple staff members communicate with the participant through the same outgoing SMS number.
 // The confirmation SMS contains a link that when clicked generates a custom page containing information on the upcoming Info Session. This signup-specific link is shortened before sent.
 //


### PR DESCRIPTION
The signup should still work if a non-required task fails such as the slack message or snap mail tasks.

The register function failed if any of the tasks failed before.
Each task now has an isRequired method that will determine if the signup needs to fail if it is a required task.
