### PR TITLE
Sign SNAP mail requests

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,6 +49,7 @@ jobs:
             OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             SNAP_MAIL_URL=${{secrets.SNAP_MAIL_URL}},
             MONGO_URI=${{secrets.MONGO_URI}},
+            SIGNING_SECRET=${{secrets.SIGNING_SECRET}},
             APP_ENV=staging
       - id: "trigger-url"
         run: 'echo "${{ steps.deploy.outputs.url }}"'

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -50,6 +50,7 @@ jobs:
             OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             SNAP_MAIL_URL=${{secrets.SNAP_MAIL_URL}},
             MONGO_URI=${{secrets.MONGO_URI}},
+            SIGNING_SECRET=${{secrets.SIGNING_SECRET}},
             APP_ENV=testing
       - id: "trigger-url"
         run: 'echo "${{ steps.deploy.outputs.url }}"'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
             OS_MESSAGING_SERVICE_URL=${{secrets.OS_MESSAGING_SERVICE_URL}},
             OS_RENDERING_SERVICE_URL=${{secrets.OS_RENDERING_SERVICE_URL}},
             SNAP_MAIL_URL=${{secrets.SNAP_MAIL_URL}},
-            MONGO_URI=${{secrets.MONGO_URI}}
+            MONGO_URI=${{secrets.MONGO_URI}},
+            SIGNING_SECRET=${{secrets.SIGNING_SECRET}}
       - id: "trigger-url"
         run: 'echo "${{ steps.deploy.outputs.url }}"'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-55.5%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.1%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/reqsign.go
+++ b/reqsign.go
@@ -1,0 +1,20 @@
+package signup
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"fmt"
+)
+
+// CreateSignature take a request body and a secret and returns a signature. The signature is hex encoded and prefixed with "sha256=".
+func createSignature(body []byte, secret []byte) ([]byte, error) {
+	mac := hmac.New(crypto.SHA256.New, secret)
+	_, err := mac.Write(body)
+	if err != nil {
+		return nil, fmt.Errorf("mac.Write: %w", err)
+
+	}
+	calculatedMAC := mac.Sum(nil)
+	signature := []byte(fmt.Sprintf("sha256=%x", calculatedMAC))
+	return signature, nil
+}

--- a/reqsign_test.go
+++ b/reqsign_test.go
@@ -1,0 +1,19 @@
+package signup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSignature(t *testing.T) {
+	t.Run("returns a signature", func(t *testing.T) {
+		secret := []byte("It's a Secret to Everybody")
+		payload := []byte("Hello, World!")
+		want := []byte("sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17")
+
+		got, err := createSignature(payload, secret)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+}

--- a/signup_test.go
+++ b/signup_test.go
@@ -754,12 +754,18 @@ func TestSnapMail(t *testing.T) {
 		mockSnapServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assertEqual(t, r.URL.Path, "/events")
 
+			signature := r.Header.Get("X-Signature-256")
+			assertEqual(t, signature, "sha256=d0c60e4c56076f1128f496fe7e6d4f696c5e8684ff407a3f25c95371e4bd9fbc")
+
 			gotJSON, err := io.ReadAll(r.Body)
 			assertNilError(t, err)
 			assertEqual(t, string(gotJSON), wantJSON)
 		}))
 
-		err := NewSnapMail(mockSnapServer.URL).run(context.Background(), su)
+		signingKey := "testkey"
+
+		err := NewSnapMail(mockSnapServer.URL, WithSigningSecret(signingKey)).run(context.Background(), su)
+
 		assertNilError(t, err)
 
 	})


### PR DESCRIPTION
The [SNAPmail service](https://github.com/OperationSpark/service-snapmail) now requires requests to be signed. We now use a SHA256 hex-encoded signature from the request body.