### PR TITLE
Remove google auth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-56.1%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.3%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/function.go
+++ b/function.go
@@ -14,7 +14,6 @@ import (
 	"github.com/operationspark/service-signup/notify"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"google.golang.org/api/idtoken"
 )
 
 type (
@@ -162,22 +161,7 @@ func NewSignupServer() *signupServer {
 	})
 
 	snapMailURL := os.Getenv("SNAP_MAIL_URL")
-
-	// If we're running in GCP (K_SERVICE env var is set), we can use the GCP Service Account to authenticate with SNAP Mail.
-	// https://cloud.google.com/functions/docs/configuring/env-var#runtime_environment_variables_set_automatically
-	snapMailOptions := []snapMailOption{}
-	if len(os.Getenv("K_SERVICE")) > 0 {
-		client, err := idtoken.NewClient(context.Background(), snapMailURL)
-		if err != nil {
-			log.Fatal(err)
-		}
-		snapMailOptions = append(
-			snapMailOptions,
-			WithClient(client),
-			WithSigningSecret(os.Getenv("SIGNING_SECRET")),
-		)
-	}
-	snapMailSvc := NewSnapMail(snapMailURL, snapMailOptions...)
+	snapMailSvc := NewSnapMail(snapMailURL, WithSigningSecret(os.Getenv("SIGNING_SECRET")))
 
 	registrationService := newSignupService(
 		signupServiceOptions{


### PR DESCRIPTION
We're no longer using Google auth to close off the snapmail service since it needs to be public for Mailgun webhooks.
We're now depending on signed payloads