### PR TITLE
Add auto-enroll variables for Mailgun template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-56.6%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.8%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/mailgun.go
+++ b/mailgun.go
@@ -52,7 +52,7 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 
 	t := mgTemplate{
 		name: m.defaultTemplate,
-		variables: map[string]string{
+		variables: map[string]interface{}{
 			"firstName":            vars.FirstName,
 			"lastName":             vars.LastName,
 			"sessionTime":          vars.SessionTime,
@@ -62,6 +62,8 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 			"locationLine1":        vars.LocationLine1,
 			"locationCityStateZip": vars.LocationCityStateZip,
 			"locationMapUrl":       vars.LocationMapURL,
+			"isGmail":              vars.IsGmail,
+			"greenlightEnrollUrl":  vars.GreenlightEnrollURL,
 		},
 	}
 
@@ -77,9 +79,9 @@ func (m MailgunService) sendWelcome(ctx context.Context, su Signup) error {
 }
 
 type mgTemplate struct {
-	name      string            // Name of mailgun template.
-	variables map[string]string // KV pairs of variables used in the email template.
-	version   string            // Mailgun template version. If not set, the active version is used.
+	name      string                 // Name of mailgun template.
+	variables map[string]interface{} // KV pairs of variables used in the email template.
+	version   string                 // Mailgun template version. If not set, the active version is used.
 }
 
 func (m MailgunService) sendWithTemplate(ctx context.Context, t mgTemplate, recipient string) error {

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -18,13 +18,15 @@ func TestSendWelcome(t *testing.T) {
 		form := Signup{
 			NameFirst:        "Henri",
 			NameLast:         "Testaroni",
-			Email:            "henri@email.com",
+			Email:            "henri@gmail.com",
 			Cell:             "555-123-4567",
 			Referrer:         "instagram",
 			ReferrerResponse: "",
 			StartDateTime:    sessionStartDate,
+			SessionID:        "this-is-a-session-id",
 			Cohort:           "is-mar-14-22-12pm",
 			JoinCode:         "tlav",
+			userJoinCode:     "user-join-code-here",
 		}
 
 		domain := "test.notarealdomain.org"
@@ -62,15 +64,18 @@ func TestSendWelcome(t *testing.T) {
 
 			assertEqual(t, gotVars.FirstName, form.NameFirst)
 			assertEqual(t, gotVars.LastName, form.NameLast)
-			assertEqual(t, gotVars.JoinCode, form.JoinCode)
 			assertEqual(t, gotVars.SessionDate, "Monday, Mar 14")
 			assertEqual(t, gotVars.SessionTime, "12:00 PM CDT")
+			assertEqual(t, gotVars.JoinCode, form.JoinCode)
+			assertEqual(t, gotVars.IsGmail, true)
+			assertEqual(t, gotVars.GreenlightEnrollURL, "https://greenlight.operationspark.org/sessions/this-is-a-session-id/?subview=overview&userJoinCode=user-join-code-here&joinCode=tlav")
 			// TODO: ZoomURL
 			// assertEqual(t, gotVars.ZoomURL, "TODO")
 
 			_, err = w.Write([]byte("{}"))
 			assertNilError(t, err)
 		}))
+
 		defer mockMailgunAPI.Close()
 
 		mgSvc := NewMailgunService(domain, apiKey, mockMailgunAPI.URL+"/v4")


### PR DESCRIPTION
Add variables for the updated Greenlight Auto-Enroll email template:
- `"greenlightEnrollUrl"`
- `"isGmail"`