### PR TITLE
Fix Post-signup Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Session Sign Up Service
 
-![Coverage](https://img.shields.io/badge/Coverage-56.0%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.1%25-yellow)
 
 When someone signs up for an Info Session on [operationspark.org](https://operationspark.org),
 this service runs a series of tasks:

--- a/signup.go
+++ b/signup.go
@@ -382,9 +382,8 @@ func (s *SignupService) register(ctx context.Context, su Signup) (Signup, error)
 
 	su.ShortLink = shortLink
 
-	// Run each task in a go routine for concurrent execution
-	// Creating a new context because the errgroup will cancel the context when
-	// Wait() is returns.
+	// Creating a new context because the errgroup will cancel the context when Wait() is returned,
+	// even with a nil error.
 	var cancel context.CancelCauseFunc
 	ctx, cancel = context.WithCancelCause(ctx)
 	g, gCtx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Fix Conversation->Signup linking
- **refactor: Improve context handling in SignupService's register method**
- **refactor: Swap parameters in Runner interface and update usage in runPostSignupTasks method**
- **feat: Skip post-signup tasks if SMS opt-in is not selected**
